### PR TITLE
Fixed makefile path to header

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -98,7 +98,7 @@ install:
 	@mkdir -p $(PREFIX)/lib
 	@mkdir -p $(PREFIX)/include
 	install -m644 $(FMSYNTH_STATIC_LIB) $(PREFIX)/lib/
-	install -m644 fmsynth.h $(PREFIX)/include/
+	install -m644 include/fmsynth.h $(PREFIX)/include/
 
 docs:
 	doxygen


### PR DESCRIPTION
Wouldn't build for me because the makefile had the wrong path to fmsynth.h … this fixed it for me.